### PR TITLE
Replace all calls to Fatalf with either Panicf or Printf+return

### DIFF
--- a/configparser/configparser.go
+++ b/configparser/configparser.go
@@ -14,17 +14,17 @@ type Config struct {
 	Sinks []sink.SinkConfig `yaml: "sinks, omitempty"`
 }
 
-func ParseConfig(path string) []sink.SinkConfig{
+func ParseConfig(path string) []sink.SinkConfig {
 	config := Config{}
 	data, err := ioutil.ReadFile(path)
 
 	if err != nil {
-		log.Fatalf("error: %v", err)
+		log.Panicf("Error reading config %v: %v", path, err)
 	}
 
 	err = yaml.Unmarshal([]byte(data), &config)
 	if err != nil {
-		log.Fatalf("error: %v", err)
+		log.Panicf("Error unmarshalling yaml: %v", err)
 	}
 
 	validateSinkConfigs(config.Sinks)
@@ -32,7 +32,7 @@ func ParseConfig(path string) []sink.SinkConfig{
 	return config.Sinks
 }
 
-func validateSinkConfigs(sinkConfigs []sink.SinkConfig){
+func validateSinkConfigs(sinkConfigs []sink.SinkConfig) {
 	validate = validator.New()
 
 	for _, sinkConfig := range sinkConfigs {

--- a/configwatcher/configwatcher.go
+++ b/configwatcher/configwatcher.go
@@ -11,7 +11,8 @@ import (
 func Watcher(path string) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		log.Fatal(err)
+		log.Printf("Error establishing file watcher: %v\n", err)
+		return
 	}
 
 	// If something goes wrong along the way, close the watcher
@@ -28,7 +29,7 @@ func Watcher(path string) {
 
 	err = watcher.Add(path)
 	if err != nil {
-		log.Fatal(err)
+		log.Panicf("Error watching path %v: %v\n", path, err)
 	}
 	<-done // Block until done
 }
@@ -52,9 +53,8 @@ func doWatch(watcher *fsnotify.Watcher, cancel context.CancelFunc, path string) 
 			if !ok {
 				continue
 			}
-			log.Println("event:", event)
 			if event.Op&fsnotify.Write == fsnotify.Write {
-				log.Println("modified file:", event.Name)
+				log.Printf("Config watcher noticed a change to %v\n", event.Name)
 				// Kill workers and start new ones
 				cancel()
 				cancel = parseAndStartWorkers(path)
@@ -63,7 +63,8 @@ func doWatch(watcher *fsnotify.Watcher, cancel context.CancelFunc, path string) 
 			if !ok {
 				continue
 			}
-			log.Println("error:", err)
+			log.Printf("Config watcher encountered an error for %v: %v\n", path, err)
+			return
 		}
 	}
 }

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -17,7 +17,7 @@ func getClient() keyvault.BaseClient {
 	client := keyvault.New()
 	a, err := iam.GetKeyvaultAuthorizer()
 	if err != nil {
-		log.Fatalf("Error authorizing: %v\n", err.Error())
+		log.Panicf("Error authorizing: %v\n", err.Error())
 	}
 	client.Authorizer = a
 	client.AddToUserAgent(config.UserAgent())
@@ -29,7 +29,8 @@ func GetKey(vaultBaseURL string, keyName string, keyVersion string) (result keyv
 
 	key, err := client.GetKey(context.Background(), vaultBaseURL, keyName, keyVersion)
 	if err != nil {
-		log.Fatalf("Error getting key: %v\n", err.Error())
+		log.Printf("Error getting key: %v\n", err.Error())
+		return
 	}
 
 	result = *key.Key
@@ -71,7 +72,8 @@ func GetKey(vaultBaseURL string, keyName string, keyVersion string) (result keyv
 func GetKeyByURL(keyURL string) (result keyvault.JSONWebKey, err error) {
 	u, err := url.Parse(keyURL)
 	if err != nil {
-		log.Fatalf("Failed to parse URL for key: %v\n", err.Error())
+		log.Printf("Failed to parse URL for key: %v\n", err.Error())
+		return
 	}
 	vaultBaseURL := fmt.Sprintf("%v://%v", u.Scheme, u.Host)
 
@@ -81,7 +83,8 @@ func GetKeyByURL(keyURL string) (result keyvault.JSONWebKey, err error) {
 
 	result, err = GetKey(vaultBaseURL, keyName, "")
 	if err != nil {
-		log.Fatalf("Failed to get key from parsed values %v and %v: %v\n", vaultBaseURL, keyName, err.Error())
+		log.Printf("Failed to get key from parsed values %v and %v: %v\n", vaultBaseURL, keyName, err.Error())
+		return
 	}
 
 	return
@@ -93,7 +96,8 @@ func GetKeys(vaultBaseURL string) (results []keyvault.JSONWebKey, err error) {
 	max := int32(25)
 	pages, err := client.GetKeys(context.Background(), vaultBaseURL, &max)
 	if err != nil {
-		log.Fatalf("Error getting key: %v\n", err.Error())
+		log.Printf("Error getting key: %v\n", err.Error())
+		return
 	}
 
 	for {
@@ -101,7 +105,8 @@ func GetKeys(vaultBaseURL string) (results []keyvault.JSONWebKey, err error) {
 			keyURL := *value.Kid
 			key, err := GetKeyByURL(keyURL)
 			if err != nil {
-				log.Fatalf("Error loading key contents: %v\n", err.Error())
+				log.Printf("Error loading key contents: %v\n", err.Error())
+				return
 			}
 
 			results = append(results, key)

--- a/main.go
+++ b/main.go
@@ -11,12 +11,12 @@ func init() {
 	var err error
 	err = config.ParseEnvironment()
 	if err != nil {
-		log.Fatalf("failed to parse env: %v\n", err.Error())
+		log.Panicf("failed to parse env: %v\n", err.Error())
 	}
 
 	err = config.AddFlags()
 	if err != nil {
-		log.Fatalf("failed to parse flags: %v\n", err.Error())
+		log.Panicf("failed to parse flags: %v\n", err.Error())
 	}
 	flag.Parse()
 }

--- a/sinkworker/sinkworker.go
+++ b/sinkworker/sinkworker.go
@@ -105,10 +105,10 @@ func fetch(ctx context.Context, cfg sink.SinkConfig) (err error) {
 		}
 
 	case sink.KeyKind:
-		log.Fatalf("Not implemented yet")
+		log.Panicf("Not implemented yet")
 
 	default:
-		log.Fatalf("Invalid sink kind: %v\n", cfg.Kind)
+		log.Panicf("Invalid sink kind: %v\n", cfg.Kind)
 	}
 
 	return


### PR DESCRIPTION
Panic bubbles up the call chain, allowing each caller to call any deferred functions before finally panicking the main thread and crashing. Fatal skips that and immediately crashes.

The cases that were replaced with Print+return are ones where we don't need to crash the agent (errors that can be continued from)