### PR TITLE
first pass at a working human readable frequency field

### DIFF
--- a/akva.yaml
+++ b/akva.yaml
@@ -1,7 +1,7 @@
 sinks:
   - kind: secret
     path: /tmp/whatever
-    frequency: 2
+    frequency: 30s
     vaultBaseURL: https://cjohnson-kv.vault.azure.net/
     name: password
     postChange: echo goodbye
@@ -9,7 +9,7 @@ sinks:
     #version: 1a131058e8934267ae695703367c485d
   - kind: cert
     path: /tmp/whatever
-    frequency: 2
+    frequency: 30s
     vaultBaseURL: https://cjohnson-kv.vault.azure.net/
     name: password
     postChange: echo goodbye

--- a/akva.yaml
+++ b/akva.yaml
@@ -9,7 +9,7 @@ sinks:
     #version: 1a131058e8934267ae695703367c485d
   - kind: cert
     path: /tmp/whatever
-    frequency: 30s
+    frequency: 1m
     vaultBaseURL: https://cjohnson-kv.vault.azure.net/
     name: password
     postChange: echo goodbye

--- a/sink/sink.go
+++ b/sink/sink.go
@@ -1,9 +1,5 @@
 package sink
 
-import (
-	"time"
-)
-
 type SinkKind string
 
 const (
@@ -13,16 +9,16 @@ const (
 )
 
 type SinkConfig struct {
-	Kind         SinkKind      `yaml:"kind,omitempty" validate:"required,oneof=cert key secret"`
-	VaultBaseURL string        `yaml:"vaultBaseURL,omitempty" validate:"required,url"`
-	Name         string        `yaml:"name,omitempty" validate:"required"`
-	Version      string        `yaml:"version,omitempty"`
-	Path         string        `yaml:"path,omitempty" validate:"required"`
-	Frequency    time.Duration `yaml:"frequency,omitempty" validate:"numeric"`
-	Template     string        `yaml:"template,omitempty"`
-	TemplatePath string        `yaml:"templatePath,omitempty"`
-	PreChange    string        `yaml:"preChange,omitempty"`
-	PostChange   string        `yaml:"postChange,omitempty"`
+	Kind         SinkKind `yaml:"kind,omitempty" validate:"required,oneof=cert key secret"`
+	VaultBaseURL string   `yaml:"vaultBaseURL,omitempty" validate:"required,url"`
+	Name         string   `yaml:"name,omitempty" validate:"required"`
+	Version      string   `yaml:"version,omitempty"`
+	Path         string   `yaml:"path,omitempty" validate:"required"`
+	Frequency    string   `yaml:"frequency,omitempty" validate:"required"`
+	Template     string   `yaml:"template,omitempty"`
+	TemplatePath string   `yaml:"templatePath,omitempty"`
+	PreChange    string   `yaml:"preChange,omitempty"`
+	PostChange   string   `yaml:"postChange,omitempty"`
 
 	/*
 	   - kind: cert

--- a/sinkworker/sinkworker.go
+++ b/sinkworker/sinkworker.go
@@ -24,9 +24,12 @@ func Worker(ctx context.Context, cfg sink.SinkConfig) {
 		if err != nil {
 			// Default time to 1m instead of 100ms if input is not valid
 			readabletime, _ = time.ParseDuration("1m")
+			log.Println("The value of Frequency was not valid, defaulting to 1m from", cfg.Frequency)
 		} else {
 			// Convert the nanoseconds to seconds
 			readabletime = time.Duration(intreadable * 1000000000)
+			log.Println("The value of Frequency was too low, defaulting to seconds from", cfg.Frequency)
+
 		}
 
 	}


### PR DESCRIPTION
This changes the frequency field in the config file to accept human readable time formations like 1h for 1 hour, or 1h30m for 1 hour 30 minutes.

It seems that the default it 100ms if the input is something that the ParseDuration function cannot understand, so even if you tell it frequency is "dog" it will just check every 100ms.

Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
https://golang.org/pkg/time/#ParseDuration