### PR TITLE
moved frequency time logic into the parser method #21

### DIFF
--- a/configparser/configparser.go
+++ b/configparser/configparser.go
@@ -1,11 +1,14 @@
 package configparser
 
 import (
+	"io/ioutil"
+	"log"
+	"strconv"
+	"time"
+
 	"github.com/chrisjohnson/azure-key-vault-agent/sink"
 	"github.com/go-playground/validator/v10"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
-	"log"
 )
 
 var validate *validator.Validate
@@ -26,20 +29,39 @@ func ParseConfig(path string) []sink.SinkConfig {
 	if err != nil {
 		log.Panicf("Error unmarshalling yaml: %v", err)
 	}
-
 	validateSinkConfigs(config.Sinks)
-
 	return config.Sinks
 }
 
 func validateSinkConfigs(sinkConfigs []sink.SinkConfig) {
 	validate = validator.New()
 
-	for _, sinkConfig := range sinkConfigs {
+	for i, sinkConfig := range sinkConfigs {
 		err := validate.Struct(sinkConfig)
-
+		sinkConfigs[i].TimeFrequency = frequencyConverter(sinkConfig.Frequency)
 		if err != nil {
 			log.Fatalf("error: %v", err)
 		}
 	}
+}
+
+func frequencyConverter(freq string) time.Duration {
+	readabletime, _ := time.ParseDuration(freq)
+
+	// If the time specified is less than 1 second, treat the value as seconds
+	if readabletime <= time.Duration(1000000000) {
+		intreadable, err := strconv.Atoi(freq)
+		if err != nil {
+			// Default time to 1m instead of 100ms if input is not valid
+			readabletime, _ = time.ParseDuration("1m")
+			log.Println("The value of Frequency was not valid, defaulting to 1m from", freq)
+		} else {
+			// Convert the nanoseconds to seconds
+			readabletime = time.Duration(intreadable * 1000000000)
+			log.Println("The value of Frequency was too low, defaulting to seconds from", freq)
+
+		}
+
+	}
+	return readabletime
 }

--- a/configparser/configparser.go
+++ b/configparser/configparser.go
@@ -49,7 +49,7 @@ func frequencyConverter(freq string) time.Duration {
 	readabletime, _ := time.ParseDuration(freq)
 
 	// If the time specified is less than 1 second, treat the value as seconds
-	if readabletime <= time.Duration(1000000000) {
+	if readabletime <= time.Duration(time.Second) {
 		intreadable, err := strconv.Atoi(freq)
 		if err != nil {
 			// Default time to 1m instead of 100ms if input is not valid
@@ -57,7 +57,7 @@ func frequencyConverter(freq string) time.Duration {
 			log.Println("The value of Frequency was not valid, defaulting to 1m from", freq)
 		} else {
 			// Convert the nanoseconds to seconds
-			readabletime = time.Duration(intreadable * 1000000000)
+			readabletime = time.Duration(intreadable) * time.Second
 			log.Println("The value of Frequency was too low, defaulting to seconds from", freq)
 
 		}

--- a/configwatcher/configwatcher.go
+++ b/configwatcher/configwatcher.go
@@ -2,10 +2,11 @@ package configwatcher
 
 import (
 	"context"
+	"log"
+
 	"github.com/chrisjohnson/azure-key-vault-agent/configparser"
 	"github.com/chrisjohnson/azure-key-vault-agent/sinkworker"
 	"github.com/fsnotify/fsnotify"
-	"log"
 )
 
 func Watcher(path string) {

--- a/sink/sink.go
+++ b/sink/sink.go
@@ -1,5 +1,7 @@
 package sink
 
+import "time"
+
 type SinkKind string
 
 const (
@@ -9,16 +11,17 @@ const (
 )
 
 type SinkConfig struct {
-	Kind         SinkKind `yaml:"kind,omitempty" validate:"required,oneof=cert key secret"`
-	VaultBaseURL string   `yaml:"vaultBaseURL,omitempty" validate:"required,url"`
-	Name         string   `yaml:"name,omitempty" validate:"required"`
-	Version      string   `yaml:"version,omitempty"`
-	Path         string   `yaml:"path,omitempty" validate:"required"`
-	Frequency    string   `yaml:"frequency,omitempty" validate:"required"`
-	Template     string   `yaml:"template,omitempty"`
-	TemplatePath string   `yaml:"templatePath,omitempty"`
-	PreChange    string   `yaml:"preChange,omitempty"`
-	PostChange   string   `yaml:"postChange,omitempty"`
+	Kind          SinkKind      `yaml:"kind,omitempty" validate:"required,oneof=cert key secret"`
+	VaultBaseURL  string        `yaml:"vaultBaseURL,omitempty" validate:"required,url"`
+	Name          string        `yaml:"name,omitempty" validate:"required"`
+	Version       string        `yaml:"version,omitempty"`
+	Path          string        `yaml:"path,omitempty" validate:"required"`
+	Frequency     string        `yaml:"frequency,omitempty" validate:"required"`
+	Template      string        `yaml:"template,omitempty"`
+	TemplatePath  string        `yaml:"templatePath,omitempty"`
+	PreChange     string        `yaml:"preChange,omitempty"`
+	PostChange    string        `yaml:"postChange,omitempty"`
+	TimeFrequency time.Duration `yaml:"timefrequency" validate:"-"`
 
 	/*
 	   - kind: cert


### PR DESCRIPTION
This implements a new field in the sink Struct called TimeFrequency and moved the logic added into the Sinkworker to the Configparser in a new function to then populate the TimeFrequency field of the sink struct with a time.Durration type value for use elsewhere.