### PR TITLE
Implement a common interface for the various resource types

### DIFF
--- a/akva.yaml
+++ b/akva.yaml
@@ -11,7 +11,7 @@ sinks:
     path: /tmp/whatever
     frequency: 1m
     vaultBaseURL: https://cjohnson-kv.vault.azure.net/
-    name: password
+    name: cjohnson-test
     postChange: echo goodbye
     preChange: echo hello
     #version: 1a131058e8934267ae695703367c485d

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -1,0 +1,6 @@
+package resource
+
+type Resource interface {
+	Map() map[string]interface{}
+	String() string
+}

--- a/sink/sink.go
+++ b/sink/sink.go
@@ -22,15 +22,4 @@ type SinkConfig struct {
 	PreChange     string        `yaml:"preChange,omitempty"`
 	PostChange    string        `yaml:"postChange,omitempty"`
 	TimeFrequency time.Duration `yaml:"timefrequency" validate:"-"`
-
-	/*
-	   - kind: cert
-	     path: /etc/nginx/certs/foo.cert
-	     refresh: 5s
-	     vaultBaseURL: https://cjohnson-kv.vault.azure.net/
-	     name: cjohnson-test-cert
-	     postChange: service nginx restart
-	     preChange: who knows
-	     version: latest # or specific version number
-	*/
 }


### PR DESCRIPTION
This way we can pass one common type into the templating package and it doesn't need to have special code variants for each type. Same with the workers. Also start stubbing out some of the remaining necessary functionality.

Also, apparently naked returns are bad practice, so clean up the code here to explicitly return named values

TODO: The `Map()` method needs to be fleshed out