### PR TITLE
Fix config watcher

### DIFF
--- a/configwatcher/configwatcher.go
+++ b/configwatcher/configwatcher.go
@@ -52,11 +52,10 @@ func doWatch(watcher *fsnotify.Watcher, cancel context.CancelFunc, path string) 
 	for {
 		select {
 		case event, ok := <-watcher.Events:
-			log.Printf("ok: %v", ok)
 			if !ok {
 				continue
 			}
-			log.Printf("event: %v", event)
+
 			if event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Rename == fsnotify.Rename {
 				log.Printf("Config watcher noticed a change to %v\n", event.Name)
 				// Kill workers and start new ones

--- a/configwatcher/configwatcher.go
+++ b/configwatcher/configwatcher.go
@@ -52,10 +52,12 @@ func doWatch(watcher *fsnotify.Watcher, cancel context.CancelFunc, path string) 
 	for {
 		select {
 		case event, ok := <-watcher.Events:
+			log.Printf("ok: %v", ok)
 			if !ok {
 				continue
 			}
-			if event.Op&fsnotify.Write == fsnotify.Write {
+			log.Printf("event: %v", event)
+			if event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Rename == fsnotify.Rename {
 				log.Printf("Config watcher noticed a change to %v\n", event.Name)
 				// Kill workers and start new ones
 				cancel()


### PR DESCRIPTION
Some editors issue a RENAME event instead of a WRITE.
fixes #39 